### PR TITLE
Update installation instructions to work on Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Allow non root acces to serial ports and install platformIO udev rules:
 
 `sudo usermod -a -G dialout $USER`
 
-`curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules`
+`curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/refs/heads/master/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules`
 
 More info: https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Download latest OpenEnergyMonitor firmware via GitHub releases; upload and test.
 - requires Python 3
 
 ``` 
-$ sudo apt-get install avrdude picocom python3 python3-pip esptool
-& pip install requirements.txt
+$ sudo apt-get install avrdude picocom python3 python3-pip python3-venv
+$ python3 -m venv .
+$ source bin/activate
+$ pip install -r requirements.txt
 ```
 
-Allow non root acces to serail ports and install platformIO udev rules:
+Allow non root acces to serial ports and install platformIO udev rules:
 
 `sudo usermod -a -G dialout $USER`
 
@@ -34,7 +36,7 @@ More info: https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules
 
 *Logout then log back in and un-plug re-plug your USB programmer for the change to take effect*
 
-Tested on Ubuntu 20.04
+Tested on Ubuntu 20.04, Debian 12
 
 
 # Run


### PR DESCRIPTION
There's no `esptool` in the apt repos in Debian anymore. It exists for old releases (buster and bullseye) but not the current release (bookworm). https://packages.debian.org/bullseye/esptool

According to Expressif, they want people to use pip to install the python package. https://docs.espressif.com/projects/esptool/en/latest/esp32/installation.html

Debian uses apt to package the global python libraries. Here's what happens when you try to run `pip install esptool` on Debian 12:

```
$ pip install esptool
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

As such, this update will create a virtual environment which will work in Ubuntu and all supported version of Debian. This allows the instructions to be uniform no matter what Linux distribution is in use.

Finally, when I was testing I found that the folks over at platformio moved the udev rules to a different directory, causing a 404 error when running the curl command. So I updated the link to point to the new location.